### PR TITLE
fix: remove early return preventing cache invalidation for account IDs

### DIFF
--- a/src/events/EventHandlerBase.ts
+++ b/src/events/EventHandlerBase.ts
@@ -62,18 +62,15 @@ export default abstract class EventHandlerBase<T extends EventSignature> {
     const accountIds = [] as AccountId[];
 
     for (const arg of args) {
-      if (isAddress(arg)) {
-        return;
-      }
-
-      try {
-        const accountId = toAccountId(arg);
-
-        if (!accountIds.includes(accountId)) {
-          accountIds.push(accountId);
+      if (!isAddress(arg)) {
+        try {
+          const accountId = toAccountId(arg);
+          if (!accountIds.includes(accountId)) {
+            accountIds.push(accountId);
+          }
+        } catch (error: any) {
+          /* empty */
         }
-      } catch (error: any) {
-        /* empty */
       }
     }
 


### PR DESCRIPTION
The early return in the address validation loop was preventing the cache invalidation block from executing, even when valid account IDs were found. Restructured the loop to properly collect all valid account IDs.