### PR TITLE
allow setting `CONFIRMATIONS` env var to 0

### DIFF
--- a/src/config/appSettings.ts
+++ b/src/config/appSettings.ts
@@ -17,7 +17,9 @@ const appSettings = {
   logLevel: process.env.LOG_LEVEL || 'debug',
   pollingInterval: Number(process.env.POLLING_INTERVAL) || 5000,
   chunkSize: Number(process.env.CHUNK_SIZE) || 1000,
-  confirmations: Number(process.env.CONFIRMATIONS) || 1,
+  confirmations: process.env.CONFIRMATIONS
+    ? Number(process.env.CONFIRMATIONS)
+    : 1,
   ipfsGatewayUrl:
     process.env.IPFS_GATEWAY_URL || 'https://drips.mypinata.cloud',
   queueUiPort: process.env.MONITORING_UI_PORT || 3000,


### PR DESCRIPTION
Makes it so that you can set `CONFIRMATIONS` to `0`. This is necessary in the local env when anvil is configured to only create new blocks on transactions, because otherwise event-processor would always lag behind by 1 interaction.