### PR TITLE
feat: add ORCID linked identity indexing support

### DIFF
--- a/src/core/splitRules.ts
+++ b/src/core/splitRules.ts
@@ -79,6 +79,13 @@ const SPLIT_RULES = Object.freeze([
     receiverAccountType: 'sub_list',
     relationshipType: 'sub_list_link',
   },
+
+  // Linked Identity Rules
+  {
+    senderAccountType: 'linked_identity',
+    receiverAccountType: 'address',
+    relationshipType: 'identity_owner',
+  },
 ] as const);
 
 type EntityIdMap = {
@@ -88,6 +95,7 @@ type EntityIdMap = {
   sub_list: ImmutableSplitsDriverId;
   deadline: RepoDeadlineDriverId;
   address: AddressDriverId;
+  linked_identity: RepoDriverId;
 };
 
 export type RelationshipType = (typeof SPLIT_RULES)[number]['relationshipType'];
@@ -139,6 +147,7 @@ export const ACCOUNT_TYPE_TO_METADATA_RECEIVER_TYPE: Record<
   ecosystem_main_account: 'ecosystem',
   sub_list: 'subList',
   address: 'address',
+  linked_identity: 'linkedIdentity',
 };
 
 export const METADATA_RECEIVER_TYPE_TO_ACCOUNT_TYPE = Object.fromEntries(

--- a/src/db/migrations/20250729112738-add-linked-identities.ts
+++ b/src/db/migrations/20250729112738-add-linked-identities.ts
@@ -1,0 +1,116 @@
+import { DataTypes, literal } from 'sequelize';
+import type { DataType, QueryInterface } from 'sequelize';
+import getSchema from '../../utils/getSchema';
+import type { DbSchema } from '../../core/types';
+import {
+  transformFieldNamesToSnakeCase,
+  transformFieldArrayToSnakeCase,
+} from './20250414133746-initial_create';
+
+export async function up({ context: sequelize }: any): Promise<void> {
+  const schema = getSchema();
+  const queryInterface: QueryInterface = sequelize.getQueryInterface();
+
+  // Add new account type to enum
+  await queryInterface.sequelize.query(`
+    ALTER TYPE ${schema}.account_type ADD VALUE IF NOT EXISTS 'linked_identity';
+  `);
+
+  // Add new relationship type to enum
+  await queryInterface.sequelize.query(`
+    ALTER TYPE ${schema}.relationship_type ADD VALUE IF NOT EXISTS 'identity_owner';
+  `);
+
+  // Create linked identity types enum
+  await queryInterface.sequelize.query(`
+    CREATE TYPE ${schema}.linked_identity_types AS ENUM (
+      'orcid'
+    );
+  `);
+
+  await createLinkedIdentitiesTable(queryInterface, schema);
+}
+
+async function createLinkedIdentitiesTable(
+  queryInterface: QueryInterface,
+  schema: DbSchema,
+) {
+  await queryInterface.createTable(
+    {
+      schema,
+      tableName: 'linked_identities',
+    },
+    transformFieldNamesToSnakeCase({
+      accountId: {
+        primaryKey: true,
+        type: DataTypes.STRING,
+      },
+      identityType: {
+        allowNull: false,
+        type: literal(`${schema}.linked_identity_types`)
+          .val as unknown as DataType,
+      },
+      ownerAddress: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
+      ownerAccountId: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
+      lastProcessedVersion: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE,
+      },
+    }),
+  );
+
+  await queryInterface.addIndex(
+    {
+      schema,
+      tableName: 'linked_identities',
+    },
+    transformFieldArrayToSnakeCase(['ownerAddress']),
+    {
+      name: 'idx_linked_identities_owner_address',
+    },
+  );
+
+  await queryInterface.addIndex(
+    {
+      schema,
+      tableName: 'linked_identities',
+    },
+    transformFieldArrayToSnakeCase(['identityType']),
+    {
+      name: 'idx_linked_identities_identity_type',
+    },
+  );
+}
+
+export async function down({ context: sequelize }: any): Promise<void> {
+  const schema = getSchema();
+  const queryInterface: QueryInterface = sequelize.getQueryInterface();
+
+  // Drop table
+  await queryInterface.dropTable({
+    schema,
+    tableName: 'linked_identities',
+  });
+
+  // Drop linked identity types enum
+  await queryInterface.sequelize.query(`
+    DROP TYPE IF EXISTS ${schema}.linked_identity_types;
+  `);
+
+  // Note: We cannot remove enum values from existing types in PostgreSQL.
+  // The 'linked_identity' and 'identity_owner' values will remain in the enums.
+}

--- a/src/db/modelRegistration.ts
+++ b/src/db/modelRegistration.ts
@@ -14,6 +14,7 @@ import {
   EcosystemMainAccountModel,
   SplitsReceiverModel,
   OwnerUpdatedEventModel,
+  LinkedIdentityModel,
 } from '../models';
 import SplitsSetEventModel from '../models/SplitsSetEventModel';
 
@@ -36,6 +37,7 @@ export function registerModels(): void {
   registerModel(GivenEventModel);
   registerModel(SplitEventModel);
   registerModel(TransferEventModel);
+  registerModel(LinkedIdentityModel);
   registerModel(SplitsReceiverModel);
   registerModel(SplitsSetEventModel);
   registerModel(StreamsSetEventModel);

--- a/src/eventHandlers/OwnerUpdatedEventHandler.ts
+++ b/src/eventHandlers/OwnerUpdatedEventHandler.ts
@@ -1,18 +1,23 @@
+import type { Transaction } from 'sequelize';
 import type { OwnerUpdatedEvent } from '../../contracts/CURRENT_NETWORK/RepoDriver';
 import {
   addressDriverContract,
   repoDriverContract,
 } from '../core/contractClients';
 import ScopedLogger from '../core/ScopedLogger';
-import type { Address, AddressDriverId } from '../core/types';
+import type { Address, AddressDriverId, RepoDriverId } from '../core/types';
 import { dbConnection } from '../db/database';
 import EventHandlerBase from '../events/EventHandlerBase';
 import type EventHandlerRequest from '../events/EventHandlerRequest';
-import { ProjectModel } from '../models';
+import { ProjectModel, LinkedIdentityModel } from '../models';
 import OwnerUpdatedEventModel from '../models/OwnerUpdatedEventModel';
-import { convertToRepoDriverId } from '../utils/accountIdUtils';
+import { convertToRepoDriverId, isOrcidAccount } from '../utils/accountIdUtils';
 import { makeVersion } from '../utils/lastProcessedVersion';
 import { calculateProjectStatus } from '../utils/projectUtils';
+import {
+  createSplitReceiver,
+  deleteExistingSplitReceivers,
+} from './AccountMetadataEmittedEvent/receiversRepository';
 
 export default class OwnerUpdatedEventHandler extends EventHandlerBase<'OwnerUpdated(uint256,address)'> {
   public readonly eventSignatures = ['OwnerUpdated(uint256,address)' as const];
@@ -73,7 +78,94 @@ export default class OwnerUpdatedEventHandler extends EventHandlerBase<'OwnerUpd
         id: `${transactionHash}-${logIndex}`,
       });
 
-      const [project, isCreation] = await ProjectModel.findOrCreate({
+      if (isOrcidAccount(accountId)) {
+        await this._handleOrcidLinkedIdentity({
+          logIndex,
+          accountId,
+          transaction,
+          blockNumber,
+          scopedLogger,
+          blockTimestamp,
+          owner: onChainOwner,
+        });
+      } else {
+        // Handle regular project.
+        const [project, isCreation] = await ProjectModel.findOrCreate({
+          transaction,
+          lock: transaction.LOCK.UPDATE,
+          where: {
+            accountId,
+          },
+          defaults: {
+            accountId,
+            ownerAddress: onChainOwner,
+            ownerAccountId: (
+              await addressDriverContract.calcAccountId(onChainOwner)
+            ).toString() as AddressDriverId,
+            claimedAt: blockTimestamp,
+            verificationStatus: 'pending_metadata',
+            isVisible: true, // Visible by default. Account metadata will set the final visibility.
+            isValid: true, // There are no receivers yet. Consider the project valid.
+            lastProcessedVersion: makeVersion(blockNumber, logIndex).toString(),
+          },
+        });
+
+        if (isCreation) {
+          scopedLogger.bufferCreation({
+            type: ProjectModel,
+            input: project,
+            id: project.accountId,
+          });
+        } else {
+          const newVersion = makeVersion(blockNumber, logIndex);
+          const storedVersion = BigInt(project.lastProcessedVersion);
+
+          // Safely update fields that another event handler could also modify.
+          if (newVersion > storedVersion) {
+            project.verificationStatus = calculateProjectStatus(project);
+          }
+
+          project.ownerAccountId = (
+            await addressDriverContract.calcAccountId(onChainOwner)
+          ).toString() as AddressDriverId;
+          project.ownerAddress = onChainOwner;
+          project.claimedAt = blockTimestamp;
+
+          project.lastProcessedVersion = newVersion.toString();
+
+          scopedLogger.bufferUpdate({
+            type: ProjectModel,
+            id: project.accountId,
+            input: project,
+          });
+
+          await project.save({ transaction });
+        }
+      }
+
+      scopedLogger.flush();
+    });
+  }
+
+  private async _handleOrcidLinkedIdentity({
+    owner,
+    logIndex,
+    accountId,
+    blockNumber,
+    transaction,
+    scopedLogger,
+    blockTimestamp,
+  }: {
+    owner: Address;
+    logIndex: number;
+    blockNumber: number;
+    blockTimestamp: Date;
+    accountId: RepoDriverId;
+    transaction: Transaction;
+    scopedLogger: ScopedLogger;
+  }): Promise<void> {
+    const [linkedIdentity, isCreation] = await LinkedIdentityModel.findOrCreate(
+      {
         transaction,
         lock: transaction.LOCK.UPDATE,
         where: {
@@ -81,51 +173,56 @@ export default class OwnerUpdatedEventHandler extends EventHandlerBase<'OwnerUpd
         },
         defaults: {
           accountId,
-          ownerAddress: onChainOwner,
+          identityType: 'orcid',
+          ownerAddress: owner,
           ownerAccountId: (
-            await addressDriverContract.calcAccountId(onChainOwner)
+            await addressDriverContract.calcAccountId(owner)
           ).toString() as AddressDriverId,
-          claimedAt: blockTimestamp,
-          verificationStatus: 'pending_metadata',
-          isVisible: true, // Visible by default. Account metadata will set the final visibility.
-          isValid: true, // There are no receivers yet. Consider the project valid.
           lastProcessedVersion: makeVersion(blockNumber, logIndex).toString(),
         },
+      },
+    );
+
+    if (isCreation) {
+      scopedLogger.bufferCreation({
+        type: LinkedIdentityModel,
+        input: linkedIdentity,
+        id: linkedIdentity.accountId,
+      });
+    } else {
+      // Update existing linked identity
+      linkedIdentity.ownerAddress = owner;
+      linkedIdentity.ownerAccountId = (
+        await addressDriverContract.calcAccountId(owner)
+      ).toString() as AddressDriverId;
+      linkedIdentity.lastProcessedVersion = makeVersion(
+        blockNumber,
+        logIndex,
+      ).toString();
+
+      scopedLogger.bufferUpdate({
+        type: LinkedIdentityModel,
+        id: linkedIdentity.accountId,
+        input: linkedIdentity,
       });
 
-      if (isCreation) {
-        scopedLogger.bufferCreation({
-          type: ProjectModel,
-          input: project,
-          id: project.accountId,
-        });
-      } else {
-        const newVersion = makeVersion(blockNumber, logIndex);
-        const storedVersion = BigInt(project.lastProcessedVersion);
+      await linkedIdentity.save({ transaction });
+    }
 
-        // Safely update fields that another event handler could also modify.
-        if (newVersion > storedVersion) {
-          project.verificationStatus = calculateProjectStatus(project);
-        }
+    await deleteExistingSplitReceivers(accountId, transaction);
 
-        project.ownerAccountId = (
-          await addressDriverContract.calcAccountId(onChainOwner)
-        ).toString() as AddressDriverId;
-        project.ownerAddress = onChainOwner;
-        project.claimedAt = blockTimestamp;
-
-        project.lastProcessedVersion = newVersion.toString();
-
-        scopedLogger.bufferUpdate({
-          type: ProjectModel,
-          id: project.accountId,
-          input: project,
-        });
-
-        await project.save({ transaction });
-      }
-
-      scopedLogger.flush();
+    await createSplitReceiver({
+      scopedLogger,
+      transaction,
+      splitReceiverShape: {
+        senderAccountId: accountId,
+        senderAccountType: 'linked_identity',
+        receiverAccountId: linkedIdentity.ownerAccountId,
+        receiverAccountType: 'address',
+        relationshipType: 'identity_owner',
+        weight: 1_000_000, // 100%
+        blockTimestamp,
+      },
     });
   }
 

--- a/src/models/LinkedIdentityModel.ts
+++ b/src/models/LinkedIdentityModel.ts
@@ -1,0 +1,78 @@
+import type {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+  Sequelize,
+} from 'sequelize';
+import { DataTypes, Model } from 'sequelize';
+import getSchema from '../utils/getSchema';
+import type { Address, AddressDriverId, RepoDriverId } from '../core/types';
+
+export const ORCID_FORGE_ID = 2;
+export const LINKED_IDENTITY_TYPES = ['orcid'] as const;
+export type LinkedIdentityType = (typeof LINKED_IDENTITY_TYPES)[number];
+
+export default class LinkedIdentityModel extends Model<
+  InferAttributes<LinkedIdentityModel>,
+  InferCreationAttributes<LinkedIdentityModel>
+> {
+  declare public accountId: RepoDriverId;
+  declare public identityType: LinkedIdentityType;
+  declare public ownerAddress: Address;
+  declare public ownerAccountId: AddressDriverId;
+  declare public lastProcessedVersion: string;
+  declare public createdAt: CreationOptional<Date>;
+  declare public updatedAt: CreationOptional<Date>;
+
+  public static initialize(sequelize: Sequelize): void {
+    this.init(
+      {
+        accountId: {
+          primaryKey: true,
+          type: DataTypes.STRING,
+        },
+        identityType: {
+          allowNull: false,
+          type: DataTypes.ENUM(...LINKED_IDENTITY_TYPES),
+        },
+        ownerAddress: {
+          allowNull: false,
+          type: DataTypes.STRING,
+        },
+        ownerAccountId: {
+          allowNull: false,
+          type: DataTypes.STRING,
+        },
+        lastProcessedVersion: {
+          allowNull: false,
+          type: DataTypes.STRING,
+        },
+        createdAt: {
+          allowNull: false,
+          type: DataTypes.DATE,
+        },
+        updatedAt: {
+          allowNull: false,
+          type: DataTypes.DATE,
+        },
+      },
+      {
+        sequelize,
+        schema: getSchema(),
+        tableName: 'linked_identities',
+        underscored: true,
+        timestamps: true,
+        indexes: [
+          {
+            fields: ['ownerAddress'],
+            name: 'idx_linked_identities_owner_address',
+          },
+          {
+            fields: ['identityType'],
+            name: 'idx_linked_identities_identity_type',
+          },
+        ],
+      },
+    );
+  }
+}

--- a/src/models/ProjectModel.ts
+++ b/src/models/ProjectModel.ts
@@ -18,6 +18,7 @@ export type ProjectVerificationStatus =
 
 export type ProjectName = `${string}/${string}`;
 
+// Note: 'orcid' IS a forge in the protocol, but it's not listed here because we index it separately as its own entity (LinkedIdentityModel).
 export const FORGES = ['github', 'gitlab'] as const;
 export type Forge = (typeof FORGES)[number];
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,6 +6,7 @@ export { default as SplitEventModel } from './SplitEventModel';
 export { default as SplitsReceiverModel } from './SplitsReceiverModel';
 export { default as TransferEventModel } from './TransferEventModel';
 export { default as SplitsSetEventModel } from './SplitsSetEventModel';
+export { default as LinkedIdentityModel } from './LinkedIdentityModel';
 export { default as StreamsSetEventModel } from './StreamsSetEventModel';
 export { default as LastIndexedBlockModel } from './LastIndexedBlockModel';
 export { default as OwnerUpdatedEventModel } from './OwnerUpdatedEventModel';

--- a/src/utils/accountIdUtils.ts
+++ b/src/utils/accountIdUtils.ts
@@ -9,6 +9,7 @@ import type {
   RepoDriverId,
   RepoSubAccountDriverId,
 } from '../core/types';
+import { ORCID_FORGE_ID } from '../models/LinkedIdentityModel';
 import unreachableError from './unreachableError';
 
 export function getContractNameFromAccountId(id: string): DripsContract {
@@ -284,4 +285,25 @@ export function assertIsAccountId(
       `Failed to assert: '${accountId}' is not a valid account ID.`,
     );
   }
+}
+
+// Forge
+export function extractForgeFromAccountId(accountId: string): number {
+  if (!isRepoDriverId(accountId)) {
+    throw new Error(
+      `Cannot extract forge: '${accountId}' is not a RepoDriver ID.`,
+    );
+  }
+
+  const accountIdAsBigInt = BigInt(accountId);
+  // Extract forgeId from bits 216-223 (8 bits after the 32-bit driver ID)
+  const forgeId = (accountIdAsBigInt >> 216n) & 0xffn;
+  return Number(forgeId);
+}
+
+export function isOrcidAccount(accountId: string): boolean {
+  return (
+    isRepoDriverId(accountId) &&
+    extractForgeFromAccountId(accountId) === ORCID_FORGE_ID
+  );
 }

--- a/tests/eventHandlers/OwnerUpdatedEventHandler.test.ts
+++ b/tests/eventHandlers/OwnerUpdatedEventHandler.test.ts
@@ -1,0 +1,336 @@
+/* eslint-disable dot-notation */
+import { Wallet } from 'ethers';
+import type { RepoDriverId } from '../../src/core/types';
+import OwnerUpdatedEventHandler from '../../src/eventHandlers/OwnerUpdatedEventHandler';
+import type EventHandlerRequest from '../../src/events/EventHandlerRequest';
+import {
+  repoDriverContract,
+  addressDriverContract,
+} from '../../src/core/contractClients';
+import { dbConnection } from '../../src/db/database';
+import OwnerUpdatedEventModel from '../../src/models/OwnerUpdatedEventModel';
+import { LinkedIdentityModel, ProjectModel } from '../../src/models';
+import * as receiversRepository from '../../src/eventHandlers/AccountMetadataEmittedEvent/receiversRepository';
+import * as projectUtils from '../../src/utils/projectUtils';
+import { makeVersion } from '../../src/utils/lastProcessedVersion';
+import ScopedLogger from '../../src/core/ScopedLogger';
+
+jest.mock('../../src/models/OwnerUpdatedEventModel');
+jest.mock('../../src/models');
+jest.mock('../../src/core/contractClients');
+jest.mock('../../src/db/database');
+jest.mock(
+  '../../src/eventHandlers/AccountMetadataEmittedEvent/receiversRepository',
+);
+jest.mock('../../src/utils/projectUtils');
+jest.mock('../../src/core/ScopedLogger');
+jest.mock('bee-queue');
+
+describe('OwnerUpdatedEventHandler', () => {
+  let handler: OwnerUpdatedEventHandler;
+  let mockRequest: EventHandlerRequest<'OwnerUpdated(uint256,address)'>;
+  let mockDbTransaction: {};
+
+  const mockOrcidAccountId =
+    '81090464584789033757396881316426232885549223458422815665819452702830' as RepoDriverId; // ORCID account
+  const mockProjectId =
+    '80904476653030408870644821256816768152249563001421913220796675056650' as RepoDriverId; // GitHub account
+  const mockOwnerAddress = Wallet.createRandom().address;
+  const mockBlockTimestamp = new Date('2025-07-29T13:00:00.000Z');
+  const mockBlockNumber = 1;
+  const mockLogIndex = 1;
+  const mockExpectedVersion = makeVersion(
+    mockBlockNumber,
+    mockLogIndex,
+  ).toString();
+  const mockGitHubBlockNumber = 2;
+  const mockGitHubLogIndex = 2;
+  const mockGitHubExpectedVersion = makeVersion(
+    mockGitHubBlockNumber,
+    mockGitHubLogIndex,
+  ).toString();
+  const mockScopedLogger = {
+    log: jest.fn(),
+    bufferCreation: jest.fn(),
+    bufferUpdate: jest.fn(),
+    flush: jest.fn(),
+  };
+
+  beforeAll(() => {
+    jest.clearAllMocks();
+
+    handler = new OwnerUpdatedEventHandler();
+
+    mockRequest = {
+      id: 'test-request-id',
+      event: {
+        args: [mockOrcidAccountId, mockOwnerAddress],
+        logIndex: mockLogIndex,
+        blockNumber: mockBlockNumber,
+        blockTimestamp: mockBlockTimestamp,
+        transactionHash: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+        eventSignature: 'OwnerUpdated(uint256,address)',
+      },
+    };
+
+    mockDbTransaction = {
+      LOCK: { UPDATE: jest.fn() },
+    };
+
+    (repoDriverContract as any).ownerOf = jest
+      .fn()
+      .mockResolvedValue(mockOwnerAddress);
+
+    (addressDriverContract as any).calcAccountId = jest
+      .fn()
+      .mockResolvedValue(123456789n);
+
+    dbConnection.transaction = jest
+      .fn()
+      .mockImplementation((callback) => callback(mockDbTransaction));
+
+    OwnerUpdatedEventModel.create = jest.fn().mockResolvedValue({
+      transactionHash: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+      logIndex: mockLogIndex,
+      blockNumber: mockBlockNumber,
+      blockTimestamp: mockBlockTimestamp,
+      accountId: mockOrcidAccountId,
+      owner: mockOwnerAddress,
+    });
+
+    (LinkedIdentityModel as any).findOrCreate = jest.fn().mockResolvedValue([
+      {
+        accountId: mockOrcidAccountId,
+        ownerAccountId: '123456789',
+      },
+      true,
+    ]);
+
+    (ProjectModel as any).findOrCreate = jest.fn().mockResolvedValue([
+      {
+        accountId: mockProjectId,
+        ownerAddress: mockOwnerAddress,
+        ownerAccountId: '123456789',
+        save: jest.fn(),
+      },
+      true,
+    ]);
+
+    (receiversRepository.createSplitReceiver as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    (receiversRepository.deleteExistingSplitReceivers as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(undefined);
+
+    (projectUtils.calculateProjectStatus as jest.Mock) = jest
+      .fn()
+      .mockReturnValue('pending_metadata');
+
+    (ScopedLogger as jest.MockedClass<typeof ScopedLogger>).mockImplementation(
+      () => mockScopedLogger as any,
+    );
+  });
+
+  it('should create an OwnerUpdatedEventModel', async () => {
+    // Arrange
+    const mockOwnerUpdatedEventModel = {
+      transactionHash: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+      logIndex: mockLogIndex,
+      blockNumber: mockBlockNumber,
+      blockTimestamp: mockBlockTimestamp,
+      accountId: mockRequest.event.args[0],
+      owner: mockRequest.event.args[1],
+    };
+
+    // Act
+    await handler['_handle'](mockRequest);
+
+    // Assert
+    expect(OwnerUpdatedEventModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transactionHash: mockOwnerUpdatedEventModel.transactionHash,
+        logIndex: mockOwnerUpdatedEventModel.logIndex,
+        blockNumber: mockOwnerUpdatedEventModel.blockNumber,
+        blockTimestamp: mockOwnerUpdatedEventModel.blockTimestamp,
+        accountId: mockOwnerUpdatedEventModel.accountId,
+        owner: mockOwnerUpdatedEventModel.owner,
+      }),
+      { transaction: mockDbTransaction },
+    );
+  });
+
+  it('should create a linked identity when account ID is ORCID', async () => {
+    // Act
+    await handler['_handle'](mockRequest);
+
+    // Assert
+    expect(LinkedIdentityModel.findOrCreate).toHaveBeenCalledWith({
+      transaction: mockDbTransaction,
+      lock: (mockDbTransaction as any).LOCK.UPDATE,
+      where: {
+        accountId: mockOrcidAccountId,
+      },
+      defaults: {
+        accountId: mockOrcidAccountId,
+        identityType: 'orcid',
+        ownerAddress: mockOwnerAddress,
+        ownerAccountId: '123456789',
+        lastProcessedVersion: mockExpectedVersion,
+      },
+    });
+
+    expect(
+      receiversRepository.deleteExistingSplitReceivers,
+    ).toHaveBeenCalledWith(mockOrcidAccountId, mockDbTransaction);
+
+    expect(receiversRepository.createSplitReceiver).toHaveBeenCalledWith({
+      scopedLogger: expect.anything(),
+      transaction: mockDbTransaction,
+      splitReceiverShape: {
+        senderAccountId: mockOrcidAccountId,
+        senderAccountType: 'linked_identity',
+        receiverAccountId: '123456789',
+        receiverAccountType: 'address',
+        relationshipType: 'identity_owner',
+        weight: 1_000_000,
+        blockTimestamp: mockBlockTimestamp,
+      },
+    });
+  });
+
+  it('should create a project when account ID is github', async () => {
+    // Arrange - Create a GitHub account request
+    const mockGitHubRequest: EventHandlerRequest<'OwnerUpdated(uint256,address)'> =
+      {
+        id: 'test-github-request-id',
+        event: {
+          args: [mockProjectId, mockOwnerAddress],
+          logIndex: mockGitHubLogIndex,
+          blockNumber: mockGitHubBlockNumber,
+          blockTimestamp: mockBlockTimestamp,
+          transactionHash: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+          eventSignature: 'OwnerUpdated(uint256,address)',
+        },
+      };
+
+    // Act
+    await handler['_handle'](mockGitHubRequest);
+
+    // Assert
+    expect(ProjectModel.findOrCreate).toHaveBeenCalledWith({
+      transaction: mockDbTransaction,
+      lock: (mockDbTransaction as any).LOCK.UPDATE,
+      where: {
+        accountId: mockProjectId,
+      },
+      defaults: {
+        accountId: mockProjectId,
+        ownerAddress: mockOwnerAddress,
+        ownerAccountId: '123456789',
+        claimedAt: mockBlockTimestamp,
+        verificationStatus: 'pending_metadata',
+        isVisible: true,
+        isValid: true,
+        lastProcessedVersion: mockGitHubExpectedVersion,
+      },
+    });
+  });
+
+  it('should update existing linked identity when account ID is ORCID', async () => {
+    // Arrange
+    const oldVersion = makeVersion(
+      mockBlockNumber - 1,
+      mockLogIndex,
+    ).toString();
+    const existingLinkedIdentity: any = {
+      accountId: mockOrcidAccountId,
+      ownerAccountId: '987654321', // Old owner account ID
+      ownerAddress: '0x1234567890123456789012345678901234567890', // Old owner address
+      lastProcessedVersion: oldVersion,
+      save: jest.fn(),
+    };
+
+    (LinkedIdentityModel as any).findOrCreate = jest
+      .fn()
+      .mockResolvedValue([existingLinkedIdentity, false]); // false = not a creation
+
+    // Act
+    await handler['_handle'](mockRequest);
+
+    // Assert
+    expect(existingLinkedIdentity.ownerAddress).toBe(mockOwnerAddress);
+    expect(existingLinkedIdentity.ownerAccountId).toBe('123456789');
+    expect(existingLinkedIdentity.lastProcessedVersion).toBe(
+      mockExpectedVersion,
+    );
+    expect(existingLinkedIdentity.save).toHaveBeenCalledWith({
+      transaction: mockDbTransaction,
+    });
+
+    expect(
+      receiversRepository.deleteExistingSplitReceivers,
+    ).toHaveBeenCalledWith(mockOrcidAccountId, mockDbTransaction);
+    expect(receiversRepository.createSplitReceiver).toHaveBeenCalledWith({
+      scopedLogger: expect.anything(),
+      transaction: mockDbTransaction,
+      splitReceiverShape: {
+        senderAccountId: mockOrcidAccountId,
+        senderAccountType: 'linked_identity',
+        receiverAccountId: '123456789',
+        receiverAccountType: 'address',
+        relationshipType: 'identity_owner',
+        weight: 1_000_000,
+        blockTimestamp: mockBlockTimestamp,
+      },
+    });
+  });
+
+  it('should update existing project when account ID is github', async () => {
+    // Arrange
+    const oldProjectVersion = makeVersion(
+      mockGitHubBlockNumber - 1,
+      mockGitHubLogIndex,
+    ).toString();
+    const existingProject: any = {
+      accountId: mockProjectId,
+      ownerAccountId: '987654321', // Old owner account ID
+      ownerAddress: '0x1234567890123456789012345678901234567890', // Old owner address
+      lastProcessedVersion: oldProjectVersion,
+      verificationStatus: 'verified', // Old status
+      claimedAt: new Date('2025-07-28T13:00:00.000Z'), // Old claimed date
+      save: jest.fn(),
+    };
+
+    (ProjectModel as any).findOrCreate = jest
+      .fn()
+      .mockResolvedValue([existingProject, false]); // false = not a creation
+
+    const mockGitHubRequest: EventHandlerRequest<'OwnerUpdated(uint256,address)'> =
+      {
+        id: 'test-github-update-request-id',
+        event: {
+          args: [mockProjectId, mockOwnerAddress],
+          logIndex: mockGitHubLogIndex,
+          blockNumber: mockGitHubBlockNumber,
+          blockTimestamp: mockBlockTimestamp,
+          transactionHash: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+          eventSignature: 'OwnerUpdated(uint256,address)',
+        },
+      };
+
+    // Act
+    await handler['_handle'](mockGitHubRequest);
+
+    // Assert
+    expect(existingProject.ownerAddress).toBe(mockOwnerAddress);
+    expect(existingProject.ownerAccountId).toBe('123456789');
+    expect(existingProject.claimedAt).toBe(mockBlockTimestamp);
+    expect(existingProject.lastProcessedVersion).toBe(
+      mockGitHubExpectedVersion,
+    );
+    expect(existingProject.save).toHaveBeenCalledWith({
+      transaction: mockDbTransaction,
+    });
+  });
+});

--- a/tests/utils/accountIdUtils.test.ts
+++ b/tests/utils/accountIdUtils.test.ts
@@ -1,0 +1,57 @@
+import {
+  extractForgeFromAccountId,
+  isOrcidAccount,
+} from '../../src/utils/accountIdUtils';
+
+describe('accountIdUtils', () => {
+  describe('extractForgeFromAccountId', () => {
+    it('should extract forge ID from different valid RepoDriver IDs', () => {
+      const testCases = [
+        {
+          accountId:
+            '80904476653030408870644821256816768152249563001421913220796675056641',
+          expectedForge: 0,
+        }, // GitHub
+        {
+          accountId:
+            '81062312897154340170689580289742573450728728362822266554565141725186',
+          expectedForge: 1,
+        }, // GitLab
+        {
+          accountId:
+            '81090464584789033757396881316426232885549223458422815665819452702820',
+          expectedForge: 2,
+        }, // ORCID
+      ];
+
+      testCases.forEach(({ accountId, expectedForge }) => {
+        const result = extractForgeFromAccountId(accountId);
+        expect(result).toBe(expectedForge);
+      });
+    });
+
+    it('should throw error for non-RepoDriver account ID', () => {
+      const addressDriverId = '123456789';
+
+      expect(() => extractForgeFromAccountId(addressDriverId)).toThrow(
+        "Cannot extract forge: '123456789' is not a RepoDriver ID.",
+      );
+    });
+  });
+
+  describe('isOrcidAccount', () => {
+    it('should return true for valid ORCID account ID', () => {
+      const orcidAccountId =
+        '81090464584789033757396881316426232885549223458422815665819452702825';
+      const result = isOrcidAccount(orcidAccountId);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for GitHub account ID', () => {
+      const githubAccountId =
+        '80904476653030408870644821256816768152249563001421913220796675056646';
+      const result = isOrcidAccount(githubAccountId);
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
  - Add LinkedIdentityModel for tracking ORCID accounts
  - Create database migration for linked_identities table
  - Update OwnerUpdatedEventHandler to handle ORCID accounts separately
  - Add split rules for linked_identity account type
  - Implement forge extraction utilities for ORCID detection
  - Add proper indexing for owner address and identity type lookups
  - Add unit tests

  This enables the system to index and track ORCID-based linked identities
  as separate entities from regular projects, with proper ownership
  relationships and split configurations.